### PR TITLE
Added option for CommonJS module compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ TemplateCompiler.prototype.processString = function (string, relativePath) {
   var template = "Ember.Handlebars.template(" + input + ");\n";
   if (this.options.module === true) {
     return "import Ember from 'ember';\nexport default " + template;
+  } else if (this.options.commonjs === true) {
+    return "var Ember = require('ember');\nmodule.exports = " + template;
   } else {
     return "Ember.TEMPLATES['" + filename + "'] = " + template;
   }

--- a/test/expected-commonjs.js
+++ b/test/expected-commonjs.js
@@ -1,0 +1,10 @@
+var Ember = require('ember');
+module.exports = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  
+
+
+  data.buffer.push("foo");
+  
+});

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -27,5 +27,11 @@ describe('broccoli-ember-hbs-template-compiler', function() {
     var expected = fs.readFileSync(path.resolve(__dirname, 'expected-module.js')).toString();
     assert(template === expected);
   });
-});
 
+  it('returns a precompiled commonjs template', function() {
+    var filter = new TemplateFilter('templates', {commonjs: true});
+    var template = filter.processString('foo', './templates/foo.hbs');
+    var expected = fs.readFileSync(path.resolve(__dirname, 'expected-commonjs.js')).toString();
+    assert(template === expected);
+  });
+});


### PR DESCRIPTION
Can be used just like `module`:

``` javascript
templates = compileTemplates('app/templates', {
    commonjs: true
});
```
